### PR TITLE
Adds builder to ThemeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,22 @@ Wrap MaterialApp with ThemeProvider widget, as it has shown in the following exa
 ```dart
   ThemeProvider(
       initTheme: initTheme,
-      child: Builder(builder: (context) {
+      builder: (context, myTheme) {
         return MaterialApp(
           title: 'Flutter Demo',
-          theme: ThemeProvider.of(context),
+          theme: myTheme,
           home: MyHomePage(),
         );
       }),
+    ),
+```
+
+But if all you want is to _provide_ a theme, use as follows:
+
+```dart
+  ThemeProvider(
+      initTheme: initTheme,
+      child: SomeCoolPage(),
     ),
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,17 +9,18 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final isPlatformDark = WidgetsBinding.instance.window.platformBrightness == Brightness.dark;
+    final isPlatformDark =
+        WidgetsBinding.instance.window.platformBrightness == Brightness.dark;
     final initTheme = isPlatformDark ? darkTheme : lightTheme;
     return ThemeProvider(
       initTheme: initTheme,
-      child: Builder(builder: (context) {
+      builder: (_, myTheme) {
         return MaterialApp(
           title: 'Flutter Demo',
-          theme: ThemeProvider.of(context),
+          theme: myTheme,
           home: MyHomePage(),
         );
-      }),
+      },
     );
   }
 }
@@ -55,7 +56,8 @@ class _MyHomePageState extends State<MyHomePage> {
                       return IconButton(
                         onPressed: () {
                           ThemeSwitcher.of(context).changeTheme(
-                            theme: ThemeProvider.of(context).brightness == Brightness.light
+                            theme: ThemeProvider.of(context).brightness ==
+                                    Brightness.light
                                 ? darkTheme
                                 : lightTheme,
                           );
@@ -104,7 +106,8 @@ class _MyHomePageState extends State<MyHomePage> {
                         child: Text('Box Animation'),
                         onPressed: () {
                           ThemeSwitcher.of(context).changeTheme(
-                            theme: ThemeProvider.of(context).brightness == Brightness.light
+                            theme: ThemeProvider.of(context).brightness ==
+                                    Brightness.light
                                 ? darkTheme
                                 : lightTheme,
                           );
@@ -119,7 +122,8 @@ class _MyHomePageState extends State<MyHomePage> {
                         child: Text('Circle Animation'),
                         onPressed: () {
                           ThemeSwitcher.of(context).changeTheme(
-                            theme: ThemeProvider.of(context).brightness == Brightness.light
+                            theme: ThemeProvider.of(context).brightness ==
+                                    Brightness.light
                                 ? darkTheme
                                 : lightTheme,
                           );
@@ -140,8 +144,11 @@ class _MyHomePageState extends State<MyHomePage> {
                         onPressed: () {
                           var brightness = ThemeProvider.of(context).brightness;
                           ThemeSwitcher.of(context).changeTheme(
-                            theme: brightness == Brightness.light ? darkTheme : lightTheme,
-                            reverseAnimation: brightness == Brightness.dark ? true : false,
+                            theme: brightness == Brightness.light
+                                ? darkTheme
+                                : lightTheme,
+                            reverseAnimation:
+                                brightness == Brightness.dark ? true : false,
                           );
                         },
                       );
@@ -155,8 +162,11 @@ class _MyHomePageState extends State<MyHomePage> {
                         onPressed: () {
                           var brightness = ThemeProvider.of(context).brightness;
                           ThemeSwitcher.of(context).changeTheme(
-                            theme: brightness == Brightness.light ? darkTheme : lightTheme,
-                            reverseAnimation: brightness == Brightness.dark ? true : false,
+                            theme: brightness == Brightness.light
+                                ? darkTheme
+                                : lightTheme,
+                            reverseAnimation:
+                                brightness == Brightness.dark ? true : false,
                           );
                         },
                       );

--- a/example/lib/with_saving_theme.dart
+++ b/example/lib/with_saving_theme.dart
@@ -36,7 +36,8 @@ class ThemeService {
   String get previousThemeName {
     String themeName = prefs.getString('previousThemeName');
     if (themeName == null) {
-      final isPlatformDark = WidgetsBinding.instance.window.platformBrightness == Brightness.dark;
+      final isPlatformDark =
+          WidgetsBinding.instance.window.platformBrightness == Brightness.dark;
       themeName = isPlatformDark ? 'light' : 'dark';
     }
     return themeName;
@@ -45,7 +46,8 @@ class ThemeService {
   get initial {
     String themeName = prefs.getString('theme');
     if (themeName == null) {
-      final isPlatformDark = WidgetsBinding.instance.window.platformBrightness == Brightness.dark;
+      final isPlatformDark =
+          WidgetsBinding.instance.window.platformBrightness == Brightness.dark;
       themeName = isPlatformDark ? 'dark' : 'light';
     }
     return allThemes[themeName];
@@ -70,13 +72,13 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ThemeProvider(
       initTheme: theme,
-      child: Builder(builder: (context) {
+      builder: (_, theme) {
         return MaterialApp(
           title: 'Flutter Demo',
-          theme: ThemeProvider.of(context),
+          theme: theme,
           home: MyHomePage(),
         );
-      }),
+      },
     );
   }
 }
@@ -111,9 +113,11 @@ class _MyHomePageState extends State<MyHomePage> {
                     builder: (context) {
                       return IconButton(
                         onPressed: () async {
-                          var themeName = ThemeProvider.of(context).brightness == Brightness.light
-                              ? 'dark'
-                              : 'light';
+                          var themeName =
+                              ThemeProvider.of(context).brightness ==
+                                      Brightness.light
+                                  ? 'dark'
+                                  : 'light';
                           var service = await ThemeService.instance
                             ..save(themeName);
                           var theme = service.getByName(themeName);
@@ -162,9 +166,11 @@ class _MyHomePageState extends State<MyHomePage> {
                       return OutlinedButton(
                         child: Text('Box Animation'),
                         onPressed: () async {
-                          var themeName = ThemeProvider.of(context).brightness == Brightness.light
-                              ? 'dark'
-                              : 'light';
+                          var themeName =
+                              ThemeProvider.of(context).brightness ==
+                                      Brightness.light
+                                  ? 'dark'
+                                  : 'light';
                           var service = await ThemeService.instance
                             ..save(themeName);
                           var theme = service.getByName(themeName);
@@ -179,9 +185,11 @@ class _MyHomePageState extends State<MyHomePage> {
                       return OutlinedButton(
                         child: Text('Circle Animation'),
                         onPressed: () async {
-                          var themeName = ThemeProvider.of(context).brightness == Brightness.light
-                              ? 'dark'
-                              : 'light';
+                          var themeName =
+                              ThemeProvider.of(context).brightness ==
+                                      Brightness.light
+                                  ? 'dark'
+                                  : 'light';
                           var service = await ThemeService.instance
                             ..save(themeName);
                           var theme = service.getByName(themeName);

--- a/lib/src/theme_provider.dart
+++ b/lib/src/theme_provider.dart
@@ -5,15 +5,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'clippers/theme_switcher_clipper.dart';
 
+typedef ThemeBuilder = Widget Function(BuildContext, ThemeData? theme);
+
 class ThemeProvider extends StatefulWidget {
   ThemeProvider({
     this.initTheme,
     Key? key,
-    required this.child,
+    this.child,
+    this.builder,
     this.duration = const Duration(milliseconds: 300),
-  }) : super(key: key);
+  })  : assert(!(child == null && builder == null),
+            'You should provide either a child or a builder'),
+        super(key: key);
 
-  final Widget child;
+  final Widget? child;
+  final ThemeBuilder? builder;
   final ThemeData? initTheme;
   final Duration duration;
 
@@ -88,7 +94,7 @@ class ThemeProviderState extends State<ThemeProvider> {
       data: this,
       child: RepaintBoundary(
         key: _previewContainer,
-        child: widget.child,
+        child: widget.child ?? widget.builder!(context, theme),
       ),
     );
   }


### PR DESCRIPTION
Adds builder parameter such that this: 
```dart
ThemeProvider(
  initTheme: initTheme,
  child: Builder(builder: (context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeProvider.of(context),
      theme: myTheme,
      home: MyHomePage(),
    );
  }),
),
```
can be simplified to this:
```dart
ThemeProvider(
  initTheme: initTheme,
  builder: (context, myTheme) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: myTheme,
      home: MyHomePage(),
    );
  }),
),
```
Also closes #22.