### PR TITLE
Bug fixes

### DIFF
--- a/lib/src/theme_provider.dart
+++ b/lib/src/theme_provider.dart
@@ -74,7 +74,7 @@ class ThemeModel extends ChangeNotifier {
   ThemeData _theme;
 
   late GlobalKey switcherGlobalKey;
-  late ui.Image image;
+  ui.Image? image;
   final previewContainer = GlobalKey();
 
   Timer? timer;


### PR DESCRIPTION
Updated late-initialized image variable to nullable variable. 
This solves the Runtime exception occurring when no image snapshot was collected. 