### PR TITLE
Add useful factory constructos to ThemeSwitcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ Wrap every switcher with ThemeSwitcher builder, and use ThemeSwitcher.of(context
     );
 ```
 
+Alternatively you could use ThemeSwitcher.switcher() or ThemeSwitcher.withTheme().  
+Builders of this constructors already provide you ThemeSwitcher.  
+ThemeSwitcher.withTheme() also provides current theme:
+
+```dart
+    ThemeSwitcher.switcher(
+      builder: (context, switcher) {
+        ...
+        onTap: () => switcher.changeTheme(
+          theme: newTheme,
+        );
+        ...
+      },
+    );
+    
+    ThemeSwitcher.withTheme(
+      builder: (context, switcher, theme) {
+        ...
+        onTap: () => switcher.changeTheme(
+          theme: theme.brightness == Brightness.light
+              ? darkTheme
+              : lightTheme,
+        );
+        ...
+      },
+    );
+```
+
 Use optional named parameter clipper to pass the custom clippers.
 
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,19 +53,14 @@ class _MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 Align(
                   alignment: Alignment.topRight,
-                  child: ThemeSwitcher(
-                    builder: (context) {
+                  child: ThemeSwitcher.withTheme(
+                    builder: (_, switcher, theme) {
                       return IconButton(
-                        onPressed: () {
-                          ThemeSwitcher.of(context).changeTheme(
-                            theme: ThemeModelInheritedNotifier.of(context)
-                                        .theme
-                                        .brightness ==
-                                    Brightness.light
-                                ? darkTheme
-                                : lightTheme,
-                          );
-                        },
+                        onPressed: () => switcher.changeTheme(
+                          theme: theme.brightness == Brightness.light
+                              ? darkTheme
+                              : lightTheme,
+                        ),
                         icon: const Icon(Icons.brightness_3, size: 25),
                       );
                     },
@@ -103,13 +98,13 @@ class _MyHomePageState extends State<MyHomePage> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  ThemeSwitcher(
+                  ThemeSwitcher.switcher(
                     clipper: const ThemeSwitcherBoxClipper(),
-                    builder: (context) {
+                    builder: (context, switcher) {
                       return OutlinedButton(
                         child: const Text('Box Animation'),
                         onPressed: () {
-                          ThemeSwitcher.of(context).changeTheme(
+                          switcher.changeTheme(
                             theme: ThemeModelInheritedNotifier.of(context)
                                         .theme
                                         .brightness ==

--- a/lib/src/theme_switcher.dart
+++ b/lib/src/theme_switcher.dart
@@ -4,6 +4,10 @@ import 'theme_provider.dart';
 import 'package:flutter/material.dart';
 
 typedef ChangeTheme = void Function(ThemeData theme);
+typedef BuilderWithSwitcher = Widget Function(
+    BuildContext, ThemeSwitcherState switcher);
+typedef BuilderWithTheme = Widget Function(
+    BuildContext, ThemeSwitcherState switcher, ThemeData theme);
 
 class ThemeSwitcher extends StatefulWidget {
   const ThemeSwitcher({
@@ -11,6 +15,29 @@ class ThemeSwitcher extends StatefulWidget {
     this.clipper = const ThemeSwitcherCircleClipper(),
     required this.builder,
   }) : super(key: key);
+
+  factory ThemeSwitcher.switcher({
+    Key? key,
+    clipper = const ThemeSwitcherCircleClipper(),
+    required BuilderWithSwitcher builder,
+  }) =>
+      ThemeSwitcher(
+        key: key,
+        clipper: clipper,
+        builder: (ctx) => builder(ctx, ThemeSwitcher.of(ctx)),
+      );
+
+  factory ThemeSwitcher.withTheme({
+    Key? key,
+    clipper = const ThemeSwitcherCircleClipper(),
+    required BuilderWithTheme builder,
+  }) =>
+      ThemeSwitcher.switcher(
+        key: key,
+        clipper: clipper,
+        builder: (ctx, s) =>
+            builder(ctx, s, ThemeModelInheritedNotifier.of(ctx).theme),
+      );
 
   final Widget Function(BuildContext) builder;
   final ThemeSwitcherClipper clipper;


### PR DESCRIPTION
Add useful switcher() and withTheme() factory constructors to ThemeSwitcher.

- switcher() adds switcher (ThemeSwitcherState) argument to builder:
```
    ThemeSwitcher.switcher(
      builder: (context, switcher) {
        ...
        onTap: () => switcher.changeTheme(
          theme: newTheme,
        );
        ...
      },
    );
```
- withTheme() also add current theme (ThemeDate):
```
    ThemeSwitcher.withTheme(
      builder: (context, switcher, theme) {
        ...
        onTap: () => switcher.changeTheme(
          theme: theme.brightness == Brightness.light
              ? darkTheme
              : lightTheme,
        );
        ...
      },
    );
```