### PR TITLE
[Bug fix] The image in the stack remains behind ThemeSwitchingArea

### DIFF
--- a/lib/src/theme_provider.dart
+++ b/lib/src/theme_provider.dart
@@ -28,7 +28,7 @@ class ThemeProvider extends StatefulWidget {
 class _ThemeProviderState extends State<ThemeProvider>
     with TickerProviderStateMixin {
   late AnimationController _controller;
-  late var model;
+  late ThemeModel model;
 
   @override
   void initState() {
@@ -42,6 +42,12 @@ class _ThemeProviderState extends State<ThemeProvider>
       startTheme: widget.initTheme,
       controller: _controller,
     );
+  }
+
+  @override
+  void dispose() {
+    model.dispose();
+    super.dispose();
   }
 
   @override
@@ -93,6 +99,7 @@ class ThemeModel extends ChangeNotifier {
   ThemeData? oldTheme;
 
   bool isReversed = false;
+  bool isAnimating = false;
   late Offset switcherOffset;
 
   void changeTheme({
@@ -117,17 +124,23 @@ class ThemeModel extends ChangeNotifier {
     switcherOffset = _getSwitcherCoordinates(key, offset);
     await _saveScreenshot();
 
+    isAnimating = true;
+
     if (isReversed) {
-      await controller
-          .reverse(from: 1.0)
-          .then((value) => onAnimationFinish?.call());
+      await controller.reverse(from: 1.0).then(
+        (value) {
+          isAnimating = false;
+          onAnimationFinish?.call();
+        },
+      );
     } else {
-      await controller
-          .forward(from: 0.0)
-          .then((value) => onAnimationFinish?.call());
+      await controller.forward(from: 0.0).then(
+        (value) {
+          isAnimating = false;
+          onAnimationFinish?.call();
+        },
+      );
     }
-    // Notify listeners when the animation finishes.
-    notifyListeners();
   }
 
   Future<void> _saveScreenshot() async {

--- a/lib/src/theme_switching_area.dart
+++ b/lib/src/theme_switching_area.dart
@@ -16,9 +16,7 @@ class ThemeSwitchingArea extends StatelessWidget {
     final model = ThemeModelInheritedNotifier.of(context);
     // Widget resChild;
     Widget child;
-    if (model.oldTheme == null ||
-        model.oldTheme == model.theme ||
-        !model.controller.isAnimating) {
+    if (model.oldTheme == null || model.oldTheme == model.theme) {
       child = _getPage(model.theme);
     } else {
       late final Widget firstWidget, animWidget;
@@ -29,12 +27,14 @@ class ThemeSwitchingArea extends StatelessWidget {
         firstWidget = RawImage(image: model.image);
         animWidget = _getPage(model.theme);
       }
+
       child = Stack(
         children: [
-          Container(
-            key: ValueKey('ThemeSwitchingAreaFirstChild'),
-            child: firstWidget,
-          ),
+          if (model.isAnimating)
+            Container(
+              key: ValueKey('ThemeSwitchingAreaFirstChild'),
+              child: firstWidget,
+            ),
           AnimatedBuilder(
             key: ValueKey('ThemeSwitchingAreaSecondChild'),
             animation: model.controller,


### PR DESCRIPTION
[Bug fix] The image in the stack remains behind ThemeSwitchingArea after changing theme, making transparent parts of application show the image from previous theme!!